### PR TITLE
Fix #7: Sprite Body Size Wonk

### DIFF
--- a/js/prefabs/Enemy.js
+++ b/js/prefabs/Enemy.js
@@ -85,9 +85,10 @@ Campaign.Enemy.prototype.damage = function(amount) {
 
 Campaign.Enemy.prototype.reset = function(x, y, health, key, scale, speedX, speedY) {
   Phaser.Sprite.prototype.reset.call(this, x, y, health);
-  
   this.loadTexture(key); // changes sprite
   this.scale.setTo(scale);
+  /* Fix body size: http://www.html5gamedevs.com/topic/13932-problem-with-arcade-bodysetsize/  */
+  this.body.setSize(this.width / this.scale.x,this.height / this.scale.y);
   this.body.velocity.x = speedX;
   this.body.velocity.y = speedY;
   //console.log(speedY);

--- a/js/states/GameState.js
+++ b/js/states/GameState.js
@@ -101,13 +101,15 @@ Campaign.GameState = {
   createEnemy: function(x, y, health, key, scale, speedX, speedY, shootFreq, bulletVelocity){
   
     var enemy = this.enemies.getFirstExists(false);
-   
+  
     if (!enemy) {
       enemy = new Campaign.Enemy(this.game, x, y, health, key, scale, speedX, speedY, this.enemyBullets, shootFreq, bulletVelocity);
       this.enemies.add(enemy);
     } else {
       enemy.reset(x, y, health, key, scale, speedX, speedY);
     }
+    
+    console.log("enemy body width: " + enemy.body.width +  " height: " + enemy.body.height + " enemy width " + enemy.width + " enemy height " + enemy.height);
     
   },
   loadLevel: function() {
@@ -153,6 +155,12 @@ Campaign.GameState = {
   },
   musicStart: function() {
     Campaign.game.technoMusic.fadeIn(2000);
+  },
+  render: function() {
+    this.enemies.forEachAlive(function(enemy){
+      this.game.debug.body(enemy);
+    }, this);
+    
   }
 
 };

--- a/js/states/Preload.js
+++ b/js/states/Preload.js
@@ -11,7 +11,7 @@ Campaign.PreloadState = {
     this.load.setPreloadSprite(this.preloadBar);
 
     //load game assets    
-    this.load.image('space', 'assets/images/space.png');    
+    this.load.image('space', 'assets/images/cyberSpace.png');    
     this.load.image('player', 'assets/images/phone.png');    
     this.load.image('bullet', 'assets/images/heartAttack.png');
     this.load.image('enemyBullet', 'assets/images/anger.png');  


### PR DESCRIPTION
After debugging with render, I noticed that any sprite body size - not just laptop - could be wonky. Finally found a fix on the [HTML5GameDev](http://www.html5gamedevs.com/topic/13932-problem-with-arcade-bodysetsize/) forum that helps to reset the body size appropriate to the current texture and the scale of the current texture.